### PR TITLE
Service and Time Compare Options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 gh-pages/
+scripts/demo_shiny_app/.Rhistory


### PR DESCRIPTION
In reference to this [issue](https://trello.com/c/CGHZGMle/27-compare-tab%3A-ability-to-compare-the-same-service-request-at-different-times).

The code is a little repeating, but I tried to keep the existing structure of separating left, right, single. etc. All logic should work, but could use a review regardless.

![screen shot 2017-06-02 at 9 07 29 am](https://cloud.githubusercontent.com/assets/8662824/26726959/f1a43546-4772-11e7-939d-c7a3123db374.jpg)

![screen shot 2017-06-02 at 9 10 15 am](https://cloud.githubusercontent.com/assets/8662824/26727069/5246b1c6-4773-11e7-9393-6277e85de532.jpg)

